### PR TITLE
change to source path given by os

### DIFF
--- a/mlb_airflow_data_pipeline/statsapi_parameters_script.py
+++ b/mlb_airflow_data_pipeline/statsapi_parameters_script.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 
 DATE_TIME_EXECUTION = datetime.today().strftime("%Y-%m-%d")
 
@@ -6,7 +7,7 @@ LEAGUE_MAPPING = {"american_league": 103, "national_league": 104}
 
 LEAGUE_DIVISION_MAPPING = {103: [200, 201, 202], 104: [203, 204, 205]}
 
-SOURCE_LOCATION = "/home/runner/work/mlb-airflow-data-pipeline/mlb-airflow-data-pipeline/mlb_airflow_data_pipeline"
+SOURCE_LOCATION = os.path.abspath("mlb_airflow_data_pipeline")
 
 # setting "national_league" as the default league name
 LEAGUE_NAME = "national_league"


### PR DESCRIPTION
Uses the `os` library to get the absolute path of `SOURCE_LOCATION`. This should allow the flexibility of running both Airflow and the GitHub actions without manual path changes. See also https://github.com/lbventura/mlb-airflow-data-pipeline/pull/26