### PR TITLE
update dag configuration

### DIFF
--- a/dags/statsapi_orchestration_al_dag.py
+++ b/dags/statsapi_orchestration_al_dag.py
@@ -9,7 +9,7 @@ default_args = {"start_date": datetime(2023, 4, 1)}
 dag_al = DAG(
     "mlb-airflow-data-pipeline-al-dag",
     default_args=default_args,
-    schedule_interval="0 09 * * *",
+    schedule="0 09 * * *",
     catchup=False,
 )
 

--- a/dags/statsapi_orchestration_nl_dag.py
+++ b/dags/statsapi_orchestration_nl_dag.py
@@ -9,7 +9,7 @@ default_args = {"start_date": datetime(2023, 4, 1)}
 dag_nl = DAG(
     "mlb-airflow-data-pipeline-nl-dag",
     default_args=default_args,
-    schedule_interval="30 08 * * *",
+    schedule="30 08 * * *",
     catchup=False,
 )
 

--- a/dags/statsapi_reporting_al_dag.py
+++ b/dags/statsapi_reporting_al_dag.py
@@ -8,7 +8,7 @@ default_args = {"start_date": datetime(2023, 4, 7)}
 dag_al = DAG(
     "mlb-airflow-data-pipeline-reporting-al-dag",
     default_args=default_args,
-    schedule_interval="0 17 * * 1",
+    schedule="0 17 * * 1",
     catchup=False,
 )
 

--- a/dags/statsapi_reporting_nl_dag.py
+++ b/dags/statsapi_reporting_nl_dag.py
@@ -8,7 +8,7 @@ default_args = {"start_date": datetime(2023, 4, 7)}
 dag_nl = DAG(
     "mlb-airflow-data-pipeline-reporting-nl-dag",
     default_args=default_args,
-    schedule_interval="30 17 * * 1",
+    schedule="30 17 * * 1",
     catchup=False,
 )
 


### PR DESCRIPTION
`schedule_interval` has been deprecated, so replace it with `interval` instead.