### PR TITLE
add full end-to-end test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    manual: marks tests that should only be run manually
+addopts = -v -m "not manual"


### PR DESCRIPTION
Initializing `airflow scheduler` and `airflow api-server --port <PORT>` each time to run an end-to-end test is rather cumbersome. Therefore, adding a rough version of an end-to-end test which runs when the `-m manual` flag is set. The inspiration for this test was the `airflow tasks test mlb-airflow-data-pipeline-al-dag extraction_task <DATE>` command.

Note: The test is failing, likely because there is some underlying problem with the code.
  